### PR TITLE
Endpoint map so that more complex endpoints can be used

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,5 +1,8 @@
 const WooCommerceAPI = require('woocommerce-api');
 const { processNode } = require('./helpers');
+const endpointMap = {
+  'categories': 'products/categories'
+};
 
 exports.sourceNodes = async (
   { boundActionCreators, createNodeId },
@@ -28,7 +31,7 @@ exports.sourceNodes = async (
   // Loop over each field set in configOptions and process/create nodes
   async function fetchNodesAndCreate (array) {
     for (const field of array) {
-      const nodes = await fetchNodes(field);
+      const nodes = await fetchNodes(endpointMap[field] ? endpointMap[field] : field);
       nodes.forEach(n=>createNode(processNode(createNodeId, n, field)));
     }
   }


### PR DESCRIPTION
I ran into an issue where I wanted to fetch categories from the woo commerce API but because only alpha numeric characters are allowed when creating node names, I couldn't pass 'products/categories' into the fields array.

This PR adds functionality where the user can pass an alpha-numeric string (i.e. 'categories') and as long as this maps to an endpoint in the map, then it will be fetched from the API.