### PR TITLE
Allow for more field types, config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ plugins:[
         consumer_key: <key>,
         consumer_secret: <secret>,
       },
+      // Version of the woocommerce API to use
+      // OPTIONAL: defaults to 'wc/v1'
+      api_version: ['wc/v3']
       // Array of strings with fields you'd like to create nodes for...
       fields: ['products']
     }
@@ -36,3 +39,7 @@ plugins:[
 - Orders
 - Reports
 - Coupons
+
+**Note**: If following the endpoint layout from the [WooCommerce REST API docs](https://woocommerce.github.io/woocommerce-rest-api-docs/?php#introduction), all fields that do not contain a wildcard *should* be supported.
+
+For example, to get product categories: including 'products/categories' in fields will show up as allWcProductsCategories / wcProductsCategories

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ plugins:[
       fields: ['products'],
       // Version of the woocommerce API to use
       // OPTIONAL: defaults to 'wc/v1'
-      api_version: ['wc/v3'],
+      api_version: 'wc/v3',
       // OPTIONAL: How many results to retrieve
       per_page: 100
     }

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ plugins:[
         consumer_key: <key>,
         consumer_secret: <secret>,
       },
+      // Array of strings with fields you'd like to create nodes for...
+      fields: ['products'],
       // Version of the woocommerce API to use
       // OPTIONAL: defaults to 'wc/v1'
-      api_version: ['wc/v3']
-      // Array of strings with fields you'd like to create nodes for...
-      fields: ['products']
+      api_version: ['wc/v3'],
+      // OPTIONAL: How many results to retrieve
+      per_page: 100
     }
   }
 ]

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,7 @@ exports.sourceNodes = async (
   const { createNode } = boundActionCreators;
   delete configOptions.plugins;
 
-  const { api, https, api_keys, fields, api_version } = configOptions;
+  const { api, https, api_keys, fields, api_version, per_page } = configOptions;
 
   // set up WooCommerce node api tool
   const WooCommerce = new WooCommerceAPI({
@@ -21,11 +21,16 @@ exports.sourceNodes = async (
 
   // Fetch Node and turn our response to JSON
   const fetchNodes = async (fieldName) => {
-    const res = await WooCommerce.getAsync(fieldName);
+    const endpoint = per_page 
+      ? fieldName + `?per_page=${per_page}`
+      : fieldName;
+
+    const res = await WooCommerce.getAsync(endpoint);
     const json = res.toJSON();
     if(json.statusCode !== 200) {
       console.warn(`
-        \n========== WARNING FOR FIELD ${fieldName} ==========\n`);
+        \n========== WARNING FOR FIELD ${fieldName} ==========\n`
+      );
       console.warn(`The following error message was produced: ${json.body}`);
       console.warn(`\n========== END WARNING ==========\n`);
       return [];

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,7 @@ exports.sourceNodes = async (
   const { createNode } = boundActionCreators;
   delete configOptions.plugins;
 
-  const { api, https, api_keys, fields } = configOptions;
+  const { api, https, api_keys, fields, api_version } = configOptions;
 
   // set up WooCommerce node api tool
   const WooCommerce = new WooCommerceAPI({
@@ -16,7 +16,7 @@ exports.sourceNodes = async (
     consumerKey: api_keys.consumer_key,
     consumerSecret: api_keys.consumer_secret,
     wpAPI: true,
-    version: 'wc/v1'
+    version: api_version || 'wc/v1'
   });
 
   // Fetch Node and turn our response to JSON

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -8,7 +8,7 @@ exports.sourceNodes = async (
   const { createNode } = boundActionCreators;
   delete configOptions.plugins;
 
-  const { api, https, api_keys, fields, api_version, per_page } = configOptions;
+  const { api, https, api_keys, fields, api_version = 'wc/v1', per_page } = configOptions;
 
   // set up WooCommerce node api tool
   const WooCommerce = new WooCommerceAPI({
@@ -16,7 +16,7 @@ exports.sourceNodes = async (
     consumerKey: api_keys.consumer_key,
     consumerSecret: api_keys.consumer_secret,
     wpAPI: true,
-    version: api_version || 'wc/v1'
+    version: api_version
   });
 
   // Fetch Node and turn our response to JSON

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -10,6 +10,7 @@ const processNode = (createNodeId, node, fieldName) => {
 
   const nodeData = Object.assign({}, node, {
     id: nodeId,
+    wordpress_id: node['id'],
     parent: null,
     children: [],
     internal: {
@@ -21,7 +22,19 @@ const processNode = (createNodeId, node, fieldName) => {
   return nodeData
 };
 
-module.exports = { processNode };
+// Turn multi part endpoints into camelCase
+// e.g. products/categories becomes productsCategories
+const normaliseFieldName = (name) => {
+  const parts = name.split('/');
+  return parts.reduce((whole, partial) => {
+    if(whole === '') {
+      return whole.concat(partial);
+    }
+    return whole.concat(partial[0].toUpperCase() + partial.slice(1));
+  }, '')
+}
+
+module.exports = { processNode, normaliseFieldName };
 
 // Helper Helpers
 function capitalize(s){


### PR DESCRIPTION
This update should allow for all endpoints to be used (as long as they don't contain any parameters, like _products/**<product_id>**/reviews_).

Config update also allows for different versions of the API to be accessed. For example, product reviews at `'products/reviews'` (available at wc/v3+).

_Edit:_ Now also allows for max retrieved item count to be configurable.